### PR TITLE
remove "/*" occurences from route titles

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -143,7 +143,7 @@ func (md *MarkdownDoc) WriteRoutes() {
 
 		// Routes
 		for _, rt := range dr.Routes {
-			md.buf.WriteString(fmt.Sprintf("%s- **%s**\n", tabs, rt.Pattern))
+			md.buf.WriteString(fmt.Sprintf("%s- **%s**\n", tabs, normalizer(rt.Pattern)))
 
 			if rt.Router != nil {
 				printRouter(depth+1, *rt.Router)
@@ -172,7 +172,7 @@ func (md *MarkdownDoc) WriteRoutes() {
 	for _, pat := range routePaths {
 		dr := md.Routes[pat]
 		md.buf.WriteString(fmt.Sprintf("<details>\n"))
-		md.buf.WriteString(fmt.Sprintf("<summary>`%s`</summary>\n", pat))
+		md.buf.WriteString(fmt.Sprintf("<summary>`%s`</summary>\n", normalizer(pat)))
 		md.buf.WriteString(fmt.Sprintf("\n"))
 		printRouter(0, dr)
 		md.buf.WriteString(fmt.Sprintf("\n"))
@@ -208,4 +208,11 @@ func (md *MarkdownDoc) githubSourceURL(file string, line int) string {
 	}
 	// absolute
 	return fmt.Sprintf("https://%s#L%d", file, line)
+}
+
+func normalizer(s string) string {
+	if strings.Contains(s, "/*") {
+		return strings.Replace(s, "/*", "", -1)
+	}
+	return s
 }


### PR DESCRIPTION
The markdown hierarchy already informs the reader there is something below the route.
I thought the wildcard thing is not that necessary. What do you guys think?

# Before
![before](https://user-images.githubusercontent.com/6259987/36537865-2d36ae0a-17b0-11e8-9952-5e448e6ed1b3.png)
# After
![after](https://user-images.githubusercontent.com/6259987/36537864-2d0ff0bc-17b0-11e8-998d-95377d26e6bb.png)


