### PR TITLE
Fix example of URLMap in MarkdownOpts struct

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -32,7 +32,7 @@ type MarkdownOpts struct {
 	// URLMap allows specifying a map of package import paths to their link sources
 	// Used for mapping vendored dependencies to their upstream sources
 	// For example:
-	// map[string]string{"github.com/my/package/vendor/go-chi/chi/": "https://github.com/go-chi/chi/blob/master/"}
+	// map[string]string{"github.com/my/package/vendor/github.com/go-chi/chi/": "https://github.com/go-chi/chi/blob/master/"}
 	URLMap map[string]string
 }
 


### PR DESCRIPTION
I changed comment URLMap in MarkdownOpts.
Usually, the package management tools(`dep`, `glide` etc) creates subdirectory named hostname under the vendor directory.

```
$ tree vendor -L  1
vendor
├── github.com
└── golang.org
```

But, the example of URLMap does not include hostname in PATH, I think correct mapping is `github.com/my/package/vendor/github.com/go-chi/chi/`.


I would appreciate it if you could check this PR.