### PR TITLE
Clean Go source code

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -44,7 +44,6 @@ func buildDocRouter(r chi.Routes) DocRouter {
 			subRoutes := rt.SubRoutes
 			subDrts := buildDocRouter(subRoutes)
 			drt.Router = &subDrts
-
 		} else {
 			hall := rt.Handlers["*"]
 			for method, h := range rt.Handlers {

--- a/docgen.go
+++ b/docgen.go
@@ -1,3 +1,4 @@
+// Package docgen generates the Chi routes documentation in JSON or Markdown.
 package docgen
 
 import (

--- a/docgen_test.go
+++ b/docgen_test.go
@@ -25,7 +25,7 @@ func hubIndexHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(s))
 }
 
-// Generate docs for the MuxBig from chi/mux_test.go
+// Generate docs for the MuxBig from chi/mux_test.go.
 func TestMuxBig(t *testing.T) {
 	// var sr1, sr2, sr3, sr4, sr5, sr6 *chi.Mux
 	var r, sr3 *chi.Mux

--- a/docgen_test.go
+++ b/docgen_test.go
@@ -178,5 +178,4 @@ func TestMuxBig(t *testing.T) {
 	fmt.Println(docgen.JSONRoutesDoc(r))
 
 	// docgen.PrintRoutes(r)
-
 }

--- a/funcinfo.go
+++ b/funcinfo.go
@@ -55,7 +55,7 @@ func GetFuncInfo(i interface{}) FuncInfo {
 	}
 
 	// Check if file info is unresolvable
-	if strings.Index(funcPath, pkgName) < 0 {
+	if !strings.Contains(funcPath, pkgName) {
 		fi.Unresolvable = true
 	}
 

--- a/markdown.go
+++ b/markdown.go
@@ -81,7 +81,6 @@ func (md *MarkdownDoc) WriteRoutes() {
 
 	var buildRoutesMap func(parentPattern string, ar, nr, dr *DocRouter)
 	buildRoutesMap = func(parentPattern string, ar, nr, dr *DocRouter) {
-
 		nr.Middlewares = append(nr.Middlewares, dr.Middlewares...)
 
 		for pat, rt := range dr.Routes {
@@ -97,7 +96,6 @@ func (md *MarkdownDoc) WriteRoutes() {
 					Router:   nnr,
 				}
 				buildRoutesMap(pattern, ar, nnr, rt.Router)
-
 			} else if len(rt.Handlers) > 0 {
 				nr.Routes[pat] = DocRoute{
 					Pattern:  pat,
@@ -111,12 +109,10 @@ func (md *MarkdownDoc) WriteRoutes() {
 					routeKey = routeKey[:len(routeKey)-1]
 				}
 				md.Routes[routeKey] = copyDocRouter(*ar)
-
 			} else {
 				panic("not possible")
 			}
 		}
-
 	}
 
 	// Build a route tree that consists of the full route pattern
@@ -130,7 +126,6 @@ func (md *MarkdownDoc) WriteRoutes() {
 	// Generate the markdown to render the above structure
 	var printRouter func(depth int, dr DocRouter)
 	printRouter = func(depth int, dr DocRouter) {
-
 		tabs := ""
 		for i := 0; i < depth; i++ {
 			tabs += "\t"

--- a/markdown.go
+++ b/markdown.go
@@ -77,7 +77,7 @@ func (md *MarkdownDoc) WriteIntro() {
 }
 
 func (md *MarkdownDoc) WriteRoutes() {
-	md.buf.WriteString(fmt.Sprintf("## Routes\n\n"))
+	md.buf.WriteString("## Routes\n\n")
 
 	var buildRoutesMap func(parentPattern string, ar, nr, dr *DocRouter)
 	buildRoutesMap = func(parentPattern string, ar, nr, dr *DocRouter) {
@@ -171,15 +171,15 @@ func (md *MarkdownDoc) WriteRoutes() {
 
 	for _, pat := range routePaths {
 		dr := md.Routes[pat]
-		md.buf.WriteString(fmt.Sprintf("<details>\n"))
+		md.buf.WriteString("<details>\n")
 		md.buf.WriteString(fmt.Sprintf("<summary>`%s`</summary>\n", pat))
-		md.buf.WriteString(fmt.Sprintf("\n"))
+		md.buf.WriteString("\n")
 		printRouter(0, dr)
-		md.buf.WriteString(fmt.Sprintf("\n"))
-		md.buf.WriteString(fmt.Sprintf("</details>\n"))
+		md.buf.WriteString("\n")
+		md.buf.WriteString("</details>\n")
 	}
 
-	md.buf.WriteString(fmt.Sprintf("\n"))
+	md.buf.WriteString("\n")
 	md.buf.WriteString(fmt.Sprintf("Total # of routes: %d\n", len(md.Routes)))
 
 	// TODO: total number of handlers..

--- a/raml/raml_test.go
+++ b/raml/raml_test.go
@@ -89,7 +89,7 @@ type Article struct {
 	Title string `json:"title"`
 }
 
-// Article fixture data
+// Article fixture data.
 var articles = []*Article{
 	{ID: "1", Title: "Hi"},
 	{ID: "2", Title: "sup"},
@@ -157,7 +157,7 @@ func DeleteArticle(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, article)
 }
 
-// A completely separate router for administrator routes
+// A completely separate router for administrator routes.
 func adminRouter() chi.Router {
 	r := chi.NewRouter()
 	r.Use(AdminOnly)


### PR DESCRIPTION
Used `golangci-lint` and fixed some linter warnings.

```
docker run --rm --user $(id -u) \
    -v $(pwd):/app -w /app      \
    -v ~/.cache:/.cache         \
    golangci/golangci-lint golangci-lint run --enable-all ./...
```